### PR TITLE
Change high calorie threshold to 300

### DIFF
--- a/amaranth/__init__.py
+++ b/amaranth/__init__.py
@@ -4,4 +4,4 @@ The only current use of this class is to define common constants.
 """
 
 LOW_CALORIE_THRESHOLD = 100
-HIGH_CALORIE_THRESHOLD = 500
+HIGH_CALORIE_THRESHOLD = 300


### PR DESCRIPTION
This change adjusts how data in the FDC data set is classified as high calorie. Now, any dish with over 300kcals per 100g of food is "high calorie." This better balances the classes in the data set, and is a more realistic number based on people eating 1.5-2kg of food per day.